### PR TITLE
fix generating week days when monday is first day of week

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,12 +1,10 @@
 import moment from 'moment'
 
 export function weekdays (locale, mondayFirst = false) {
-  let weekdays = moment.localeData(locale).weekdaysMin()
-
+  const weekdays = moment.localeData(locale).weekdaysMin()
   if (mondayFirst) {
-    weekdays.push(weekdays.shift())
+    return weekdays.slice(1).concat(weekdays[0])
   }
-
   return weekdays
 }
 


### PR DESCRIPTION
Hey, thanks for your component, but I've found one issue, which appeared when I used it two times on one page with option `monday-first`.  

### Description: 
This PR fix problem, when more then one date time picker component appears on page with option `monday-first`.

### How to reproduce the problem:
The fast way is to run `weekdays` function from `utils.js` with same arguments to times:
```
weekdays('en', true); // ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
weekdays('en', true); // ["Tu", "We", "Th", "Fr", "Sa", "Su", "Mo"] - problem, expected ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
```

### Decision:

Using `slice` and `concat` methods of `array` to return new array instead modifying existing one.
