### PR TITLE
Fixed bug in required prop

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -8,7 +8,7 @@
                :placeholder="placeholder"
                :value="inputValue"
                :class="inputClass"
-               :required="required"
+               :required.boolean="required"
                @click="open"
                @focus="open"/>
         <transition name="vdatetime-fade">


### PR DESCRIPTION
"required" is a Boolean attribute of input fields in html which means the only way to control it's behaviour is by having it present or absent

e.g

`<input type="text" required> // Means it's required`

and Omitting the attribute entirely

`<input type="text"> // Means it's not  required`

More explanation here: https://stackoverflow.com/a/4140263/3734244

The correct way to do this in Vue is the use the `.boolean` modifier and then based on the value (true/false) Vue will generate the appropriate HTML markup.