### PR TITLE
Added Readonly prop

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -4,7 +4,7 @@
                v-bind="$attrs"
                v-on="$listeners"
                type="text"
-               readonly="readonly"
+               :readonly="readonly"
                :placeholder="placeholder"
                :value="inputValue"
                :class="inputClass"
@@ -125,6 +125,10 @@
         default: false
       },
       required: {
+        type: Boolean,
+        default: false
+      },
+      readonly: {
         type: Boolean,
         default: false
       },


### PR DESCRIPTION
Why?
Because in the HTML Specification You can't have a required field that's also readonly at the same time, so i decided to add a prop to control that and set it to false.

This allows devs to make the input field required without this, required wouldn't work because the field is readonly by default.

The real solution to this problem IMO is to get rid of the readonly attribute because there's no need for it. After all, the users can't interact/change the value in the text field because once it's focused on, the date picker pops up.

Or Is there any special need for the readonly attribute ?