### PR TITLE
Fix value formatting with `type=date` and specified time zone

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -143,7 +143,7 @@ export default {
       let datetime = this.datetime ? this.datetime.setZone(this.valueZone) : null
 
       if (datetime && this.type === 'date') {
-        datetime = startOfDay(this.datetime)
+        datetime = startOfDay(datetime)
       }
 
       this.$emit('input', datetime ? datetime.toISO() : '')

--- a/test/specs/Datetime.spec.js
+++ b/test/specs/Datetime.spec.js
@@ -292,6 +292,21 @@ describe('Datetime.vue', function () {
 
       expect(vm.datetime).to.be.equal('2017-12-07T00:00:00.000Z')
     })
+
+    it('should be a date with cleared time in the specified time zone when type is date', function () {
+      const vm = createVM(this,
+        `<Datetime type="date" v-model="datetime" value-zone="UTC+03:00"></Datetime>`,
+        {
+          components: { Datetime },
+          data () {
+            return {
+              datetime: '2017-12-07T22:34:54.078Z'
+            }
+          }
+        })
+
+      expect(vm.datetime).to.be.equal('2017-12-08T00:00:00.000+03:00')
+    })
   })
 
   describe('input value', function () {


### PR DESCRIPTION
Currently, `value-zone` is ignored if `type` is set to `date`. This is most probably a typo, the fix is one line.

Example demonstrating the problem:

```vue
<template>
<div>
  <datetime type="date" v-model="dt" value-zone="local" />
  Value: {{ dt }}
</div>
</template>

<script>
import { DateTime } from 'luxon'

export default {
	data () {
		return {
			dt: DateTime.local().toISO(),
		}
	},
}
</script>
```

This will print `2018-04-25T00:00:00.000Z` and not `2018-04-25T00:00:00.000+07:00` (or whatever is the local time zone).

The PR also includes the regression test.