### PR TITLE
format:macro tokens are supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ type | `String` | `date` | Picker type. date or datetime.
 input-class | `String` | `''` | Class for the input.
 value-zone | `String` | `UTC` | Time zone for the value.
 zone | `String` | `local` | Time zone for the picker.
-format | `String` | `DateTime.DATE_MED` or `DateTime.DATETIME_MED` | Input date format.
+format | `Object` or `String` | `DateTime.DATE_MED` or `DateTime.DATETIME_MED` or yyyy-MM-dd | Input date format.
 phrases | `Object` | `{ok: 'Ok', cancel: 'Cancel'}` | Phrases.
 use12-hour | `Boolean` | `false` | Display 12 hour (AM/PM) mode
 hour-step | `Number` | `1` | Hour step.

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ type | `String` | `date` | Picker type. date or datetime.
 input-class | `String` | `''` | Class for the input.
 value-zone | `String` | `UTC` | Time zone for the value.
 zone | `String` | `local` | Time zone for the picker.
-format | `Object` or `String` | `DateTime.DATE_MED` or `DateTime.DATETIME_MED` or yyyy-MM-dd | Input date format.
+format | `Object` or `String` | `DateTime.DATE_MED` or `DateTime.DATETIME_MED` or `yyyy-MM-dd` | Input date format.
 phrases | `Object` | `{ok: 'Ok', cancel: 'Cancel'}` | Phrases.
 use12-hour | `Boolean` | `false` | Display 12 hour (AM/PM) mode
 hour-step | `Number` | `1` | Hour step.

--- a/demo/index.html
+++ b/demo/index.html
@@ -66,6 +66,22 @@
     </div>
   </div>
 
+  <h2>Macro tokens</h2>
+  <div class="example">
+      <div class="example-inputs">
+          <datetime type="datetime" v-model="datetime13" format="yyyy-MM-dd HH:mm:ss"></datetime>
+
+          <div class="values">
+              <p>
+                  <strong>Value:</strong> {{ datetime13 }}
+              </p>
+          </div>
+      </div>
+      <div class="example-code">
+          <pre><code>&#x3C;datetime type=&#x22;datetime&#x22; v-model=&#x22;datetime13&#x22; format=&#x22;yyyy-MM-dd HH:mm:ss&#x22;&#x3E;&#x3C;/datetime&#x3E;</code></pre>
+      </div>
+  </div>
+
   <h2>Complete demo</h2>
 
   <div class="example">

--- a/demo/src/app.js
+++ b/demo/src/app.js
@@ -14,6 +14,7 @@ new Vue({
       date: '2018-05-12T00:00:00.000Z',
       datetime: '2018-05-12T17:19:06.151Z',
       datetime12: '2018-05-12T17:19:06.151Z',
+      datetime13: '2018-05-12T17:19:06.151Z',
       datetimeEmpty: '',
       minDatetime: LuxonDateTime.local().minus({ days: 3 }).toISO(),
       maxDatetime: LuxonDateTime.local().plus({ days: 3 }).toISO(),

--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -56,7 +56,7 @@ export default {
       default: 'local'
     },
     format: {
-      type: Object,
+      type: [Object,String],
       default: null
     },
     type: {
@@ -125,7 +125,11 @@ export default {
     inputValue () {
       const format = this.format || (this.type === 'date' ? DateTime.DATE_MED : DateTime.DATETIME_MED)
 
-      return this.datetime ? this.datetime.setZone(this.zone).toLocaleString(format) : ''
+      if (typeof format === 'string') {
+        return this.datetime ? DateTime.fromISO(this.datetime).toFormat(format) : ''
+      } else {
+        return this.datetime ? this.datetime.setZone(this.zone).toLocaleString(format) : ''
+      }
     },
     popupDate () {
       return this.datetime ? this.datetime.setZone(this.zone) : DateTime.utc().setZone(this.zone)

--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -56,7 +56,7 @@ export default {
       default: 'local'
     },
     format: {
-      type: [Object,String],
+      type: [Object, String],
       default: null
     },
     type: {


### PR DESCRIPTION
The current format parameters have low extensibility. Add String format to the format parameters without affecting users and allow users to use Macro tokens in Luxon.