### PR TITLE
apply default rounded time when using minute step - resolves #56

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -128,7 +128,7 @@ export default {
       return this.datetime ? this.datetime.setZone(this.zone).toLocaleString(format) : ''
     },
     popupDate () {
-      return this.datetime ? this.datetime.setZone(this.zone) : DateTime.utc().setZone(this.zone)
+      return this.datetime ? this.datetime.setZone(this.zone) : this.roundMinute()
     },
     popupMinDatetime () {
       return this.minDatetime ? DateTime.fromISO(this.minDatetime) : null
@@ -163,6 +163,19 @@ export default {
     },
     cancel () {
       this.close()
+    },
+    roundMinute () {
+      if (this.minuteStep === 1) {
+        return DateTime.utc().setZone(this.zone)
+      }
+
+      const roundedMinute = Math.round(DateTime.utc().setZone(this.zone).minute / this.minuteStep) * this.minuteStep
+
+      if (roundedMinute === 60) {
+        return DateTime.utc().setZone(this.zone).plus({ hours: 1 }).set({ minute: 0 })
+      }
+
+      return DateTime.utc().setZone(this.zone).set({ minute: roundedMinute })
     }
   }
 }


### PR DESCRIPTION
If minute-step is something other than 1, a default time will not be applied when opening the timepicker. If no minute is selected, the current minute will be selected and not a rounded minute.

This PR resolves that issue and closes issue #56.