### PR TITLE
Fix datetime popup display bug when using UTC zone

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -144,10 +144,10 @@ export default {
       return this.datetime ? this.datetime.setZone(this.zone) : this.newPopupDatetime()
     },
     popupMinDatetime () {
-      return this.minDatetime ? DateTime.fromISO(this.minDatetime) : null
+      return this.minDatetime ? DateTime.fromISO(this.minDatetime).setZone(this.zone) : null
     },
     popupMaxDatetime () {
-      return this.maxDatetime ? DateTime.fromISO(this.maxDatetime) : null
+      return this.maxDatetime ? DateTime.fromISO(this.maxDatetime).setZone(this.zone) : null
     }
   },
 

--- a/src/DatetimeCalendar.vue
+++ b/src/DatetimeCalendar.vue
@@ -59,7 +59,7 @@ export default {
 
   data () {
     return {
-      newDate: DateTime.fromObject({ year: this.year, month: this.month, timeZone: 'UTC' }),
+      newDate: DateTime.fromObject({ year: this.year, month: this.month, zone: 'utc' }),
       weekdays: weekdays(this.weekStart),
       months: months()
     }

--- a/src/util.js
+++ b/src/util.js
@@ -31,7 +31,7 @@ export function monthDays (year, month, weekStart) {
 }
 
 export function monthDayIsDisabled (minDate, maxDate, year, month, day) {
-  const date = DateTime.fromObject({ year, month, day })
+  const date = DateTime.fromObject({ year, month, day, zone: 'utc' })
 
   minDate = minDate ? startOfDay(minDate) : null
   maxDate = maxDate ? startOfDay(maxDate) : null


### PR DESCRIPTION
fixes #82 

I also renamed the `timeZone` to `zone` since it has been changed in luxon.