### PR TITLE
Min/Max props for year picker

### DIFF
--- a/src/DatetimePopup.vue
+++ b/src/DatetimePopup.vue
@@ -8,6 +8,8 @@
       <datetime-year-picker
           v-if="step === 'year'"
           @change="onChangeYear"
+          :min-date="minDatetime"
+          :max-date="maxDatetime"
           :year="year"></datetime-year-picker>
       <datetime-calendar
           v-if="step === 'date'"

--- a/src/DatetimeYearPicker.vue
+++ b/src/DatetimeYearPicker.vue
@@ -1,19 +1,31 @@
 <template>
   <div class="vdatetime-year-picker">
     <div class="vdatetime-year-picker__list vdatetime-year-picker__list" ref="yearList">
-      <div class="vdatetime-year-picker__item" v-for="year in years" @click="select(year.number)" :class="{'vdatetime-year-picker__item--selected': year.selected}">{{ year.number }}</div>
+      <div class="vdatetime-year-picker__item" v-for="year in years" @click="select(year)" :class="{
+        'vdatetime-year-picker__item--selected': year.selected,
+        'vdatetime-year-picker__item--disabled': year.disabled
+      }">{{ year.number }}</div>
     </div>
   </div>
 </template>
 
 <script>
-import { years } from './util'
+import { DateTime } from 'luxon'
+import { yearIsDisabled, years } from './util'
 
 export default {
   props: {
     year: {
       type: Number,
       required: true
+    },
+    minDate: {
+      type: DateTime,
+      default: null
+    },
+    maxDate: {
+      type: DateTime,
+      default: null
     }
   },
 
@@ -21,14 +33,16 @@ export default {
     years () {
       return years(this.year).map(year => ({
         number: year,
-        selected: year === this.year
+        selected: year === this.year,
+        disabled: !year || yearIsDisabled(this.minDate, this.maxDate, year)
       }))
     }
   },
 
   methods: {
     select (year) {
-      this.$emit('change', parseInt(year))
+      if (year.disabled) return
+      this.$emit('change', parseInt(year.number))
     },
 
     scrollToCurrent () {
@@ -96,5 +110,15 @@ export default {
 .vdatetime-year-picker__item--selected {
   color: #3f51b5;
   font-size: 32px;
+}
+
+.vdatetime-year-picker__item--disabled {
+  opacity: 0.4;
+  cursor: default;
+
+  &:hover {
+    color: inherit;
+    background: transparent;
+  }
 }
 </style>

--- a/src/util.js
+++ b/src/util.js
@@ -40,6 +40,13 @@ export function monthDayIsDisabled (minDate, maxDate, year, month, day) {
          (maxDate && date > maxDate)
 }
 
+export function yearIsDisabled (minDate, maxDate, year) {
+  minDate = minDate ? minDate.year : null
+  maxDate = maxDate ? maxDate.year : null
+  return (minDate && year < minDate) ||
+         (maxDate && year > maxDate)
+}
+
 export function timeComponentIsDisabled (min, max, component) {
   return (min && component < min) ||
          (max && component > max)

--- a/test/specs/DatetimeYearPicker.spec.js
+++ b/test/specs/DatetimeYearPicker.spec.js
@@ -1,3 +1,4 @@
+import { DateTime } from 'luxon'
 import { createVM } from '../helpers/utils.js'
 import DatetimeYearPicker from 'src/DatetimeYearPicker.vue'
 
@@ -42,6 +43,50 @@ describe('DatetimeYearPicker.vue', function () {
 
       vm.$$('.vdatetime-year-picker__list .vdatetime-year-picker__item')[110].click()
       expect(vm.year).to.be.equal(2030)
+    })
+
+    it('should disable change event when year is disabled', function () {
+      const vm = createVM(this,
+        `<DatetimeYearPicker :min-date="minDate" :max-date="maxDate" :year="2018"></DatetimeYearPicker>`,
+        {
+          components: { DatetimeYearPicker },
+          data () {
+            return {
+              minDate: DateTime.fromISO('1920-01-01'),
+              maxDate: DateTime.fromISO('2000-12-01')
+            }
+          }
+        })
+      vm.$$('.vdatetime-year-picker__list .vdatetime-year-picker__item')[0].click()
+      expect(vm.year).not.to.be.equal(1918)
+    })
+  })
+
+  describe('min/max validation', function () {
+    it('should add disabled class', function () {
+      const vm = createVM(this,
+        `<DatetimeYearPicker :min-date="minDate" :max-date="maxDate" :year="2018"></DatetimeYearPicker>`,
+        {
+          components: { DatetimeYearPicker },
+          data () {
+            return {
+              minDate: DateTime.fromISO('2018-01-01'),
+              maxDate: DateTime.fromISO('2018-12-01')
+            }
+          }
+        })
+
+      const years = vm.$$('.vdatetime-year-picker__list .vdatetime-year-picker__item')
+      for (var i = 0; i < years.length; i++) {
+        const yearEl = years[i]
+        if (yearEl.textContent === '2018') {
+          expect(yearEl.className).to.have.string('vdatetime-year-picker__item--selected')
+          console.log(yearEl.textContent)
+          console.log(yearEl.className)
+          continue
+        }
+        expect(yearEl.className).to.have.string('vdatetime-year-picker__item--disabled')
+      }
     })
   })
 })

--- a/test/specs/DatetimeYearPicker.spec.js
+++ b/test/specs/DatetimeYearPicker.spec.js
@@ -81,8 +81,6 @@ describe('DatetimeYearPicker.vue', function () {
         const yearEl = years[i]
         if (yearEl.textContent === '2018') {
           expect(yearEl.className).to.have.string('vdatetime-year-picker__item--selected')
-          console.log(yearEl.textContent)
-          console.log(yearEl.className)
           continue
         }
         expect(yearEl.className).to.have.string('vdatetime-year-picker__item--disabled')


### PR DESCRIPTION
Hi again, this changes will disable the year selection when the year does not fit in the min, max values.

Some screenshot that I took from the [tests](https://github.com/mariomka/vue-datetime/compare/v1.x...codekraft-studio:features/disable-year#diff-8d2182b25d9c5efd7fc74001f1c9ae3f) of this feature:

![image](https://user-images.githubusercontent.com/29862596/44048400-8194e9ae-9f31-11e8-90c3-79c83d07fd58.png)

![image](https://user-images.githubusercontent.com/29862596/44048502-cedf7d1e-9f31-11e8-8572-dc1d34c92bbc.png)

