### PR TITLE
Provide a fix for #88

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -179,7 +179,11 @@ export default {
       this.close()
     },
     newPopupDatetime () {
-      const datetime = DateTime.utc().setZone(this.zone).set({ seconds: 0, milliseconds: 0 })
+      let datetime = DateTime.utc().setZone(this.zone).set({ seconds: 0, milliseconds: 0 })
+
+      if (this.popupMinDatetime && datetime < this.popupMinDatetime) {
+        datetime = this.popupMinDatetime
+      }
 
       if (this.minuteStep === 1) {
         return datetime

--- a/test/specs/Datetime.spec.js
+++ b/test/specs/Datetime.spec.js
@@ -547,6 +547,26 @@ describe('Datetime.vue', function () {
         done()
       }, 50)
     })
+
+    it('should set datetime to min if min is bigger than datetime', function (done) {
+      const vm = createVM(this,
+        `<Datetime type="datetime" :min-datetime="minDatetime"></Datetime>`,
+        {
+          components: { Datetime },
+          data () {
+            return {
+              minDatetime: LuxonDateTime.utc().plus({ years: 5 })
+            }
+          }
+        })
+
+      vm.$('.vdatetime-input').click()
+
+      vm.$nextTick(() => {
+        expect(vm.$findChild('.vdatetime-popup').datetime.toUTC().toISO()).to.be.equal(vm.$findChild('.vdatetime-popup').minDatetime.toUTC().toISO())
+        done()
+      })
+    })
   })
 
   describe('week start', function () {


### PR DESCRIPTION
We should set the datetime to minDatetime if it's bigger than datetime itself.
Fixes #88.