### PR TITLE
Added height to month selection arrows

### DIFF
--- a/src/DatetimeCalendar.vue
+++ b/src/DatetimeCalendar.vue
@@ -124,6 +124,7 @@ export default {
   cursor: pointer;
 
   & svg {
+    height: 8px;
     width: 8px;
 
     & path {


### PR DESCRIPTION
Added a height to month selection arrows. In some browsers the default height for an svg seems to be very high, stretching the svg to the bottom of the modal.