### PR TITLE
added a check to see if yearList ref exists

### DIFF
--- a/src/DatetimeYearPicker.vue
+++ b/src/DatetimeYearPicker.vue
@@ -47,8 +47,10 @@ export default {
     },
 
     scrollToCurrent () {
-      const selectedYear = this.$refs.yearList.querySelector('.vdatetime-year-picker__item--selected')
-      this.$refs.yearList.scrollTop = selectedYear ? selectedYear.offsetTop - 250 : 0
+      if (this.$refs.yearList) {
+        const selectedYear = this.$refs.yearList.querySelector('.vdatetime-year-picker__item--selected')
+        this.$refs.yearList.scrollTop = selectedYear ? selectedYear.offsetTop - 250 : 0
+      }
     }
   },
 


### PR DESCRIPTION
For some reason I get error reports saying `this.$refs.yearList` is undefined. If `scrollToCurrent` fails the user needs to scroll a lot to get to the current year. Which I think is better than having an error and not nothing working.