### PR TITLE
Popup exposed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-datetime",
+  "name": "@escofieldpublic/vue-datetime",
   "version": "1.0.0-beta.10",
   "description": "Mobile friendly datetime picker for Vue. Supports date, datetime and time modes, i18n and disabling dates.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escofieldpublic/vue-datetime",
-  "version": "1.0.0-es-beta.11",
+  "version": "1.0.0-es-beta.12",
   "description": "Mobile friendly datetime picker for Vue. Supports date, datetime and time modes, i18n and disabling dates.",
   "keywords": [
     "datetime",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escofieldpublic/vue-datetime",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-es-beta.11",
   "description": "Mobile friendly datetime picker for Vue. Supports date, datetime and time modes, i18n and disabling dates.",
   "keywords": [
     "datetime",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Datetime from './Datetime.vue'
-
+import DatetimePopup from './DatetimePopup.vue'
 function plugin (Vue) {
   Vue.component('datetime', Datetime)
 }
@@ -14,6 +14,7 @@ const version = '__VERSION__'
 
 // Export all components too
 export {
+  DatetimePopup,
   Datetime,
   version
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import Datetime from './Datetime.vue'
 import DatetimePopup from './DatetimePopup.vue'
 function plugin (Vue) {
   Vue.component('datetime', Datetime)
+  Vue.component('datetime-popup', DatetimePopup)
 }
 
 // Install by default if using the script tag


### PR DESCRIPTION
Expose the Popup so I can utilize the date popup without a text field.   Furthermore, this gives me direct access to the Luxon date object, sweet!   No changes were made to include the overlay into the popup or other substantial changes, this will need to be handled by the user.  But this does add flexibility to integrate it directly on a page, in fact it may make sense for future revisions to remove from vdatetime-popup 
    z-index: 1000;
    position: fixed;
    top: 50%;
    left: 50%;
    transform: translate(-50%, -50%);
and do some CSS trickory like
vdatetime-overlay + vdatetime-popup{ 
    z-index: 1000;
    position: fixed;
    top: 50%;
    left: 50%;
    transform: translate(-50%, -50%);
}
Thanks for a beautiful date time picker..