### PR TITLE
support user defined output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Download vue, luxon, weekstart and vue-datetime or use a CDN like unpkg.
 
 Parameter | Type | Default | Description
 --------- | ---- | ------- | -----------
-v-model (*required*) | ISO 8601 `String` | - | Datetime.
+v-model (*required*) | ISO 8601 `String` or formatted as `valueFormat` if supplied | - | Datetime.
 type | `String` | `date` | Picker type: date, datetime or time.
 input-id | `String` | `''` | Id for the input.
 input-class | `String`, `Array` or `Object` | `''` | Class for the input.
@@ -102,6 +102,7 @@ hidden-name | `String` | `null` | Name for hidden input with raw value. See #51.
 value-zone | `String` | `UTC` | Time zone for the value.
 zone | `String` | `local` | Time zone for the picker.
 format | `Object` or `String` | `DateTime.DATE_MED`, `DateTime.DATETIME_MED` or `DateTime.TIME_24_SIMPLE` | Input date format. Luxon [presets](https://moment.github.io/luxon/docs/manual/formatting.html#tolocalestring--strings-for-humans-) or [tokens](https://moment.github.io/luxon/docs/manual/formatting.html#formatting-with-tokens--strings-for-cthulhu-).
+value-format | `String` | ISO 8601 `String` | Output date format.
 phrases | `Object` | `{ok: 'Ok', cancel: 'Cancel'}` | Phrases.
 use12-hour | `Boolean` | `false` | Display 12 hour (AM/PM) mode
 hour-step | `Number` | `1` | Hour step.

--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -46,7 +46,7 @@
 <script>
 import { DateTime } from 'luxon'
 import DatetimePopup from './DatetimePopup'
-import { datetimeFromISO, startOfDay, weekStart } from './util'
+import { datetimeFromISO, datetimeFromFormat, startOfDay, weekStart } from './util'
 
 export default {
   components: {
@@ -57,7 +57,8 @@ export default {
 
   props: {
     value: {
-      type: String
+      type: String,
+      default: ''
     },
     valueZone: {
       type: String,
@@ -84,6 +85,10 @@ export default {
     },
     format: {
       type: [Object, String],
+      default: null
+    },
+    valueFormat: {
+      type: String,
       default: null
     },
     type: {
@@ -140,13 +145,13 @@ export default {
   data () {
     return {
       isOpen: false,
-      datetime: datetimeFromISO(this.value)
+      datetime: this.prepareDateString(this.value)
     }
   },
 
   watch: {
     value (newValue) {
-      this.datetime = datetimeFromISO(newValue)
+      this.datetime = this.prepareDateString(newValue)
     }
   },
 
@@ -198,7 +203,13 @@ export default {
         datetime = startOfDay(datetime)
       }
 
-      this.$emit('input', datetime ? datetime.toISO() : '')
+      if (this.valueFormat) {
+        datetime = datetime ? datetime.toFormat(this.valueFormat) : ''
+      } else {
+        datetime = datetime ? datetime.toISO() : ''
+      }
+
+      this.$emit('input', datetime)
     },
     open (event) {
       event.target.blur()
@@ -240,8 +251,19 @@ export default {
 
       return datetime.set({ minute: roundedMinute })
     },
+    prepareDateString (string) {
+      let datetime
+
+      if (this.valueFormat) {
+        datetime = datetimeFromFormat(string, this.valueFormat, this.valueZone)
+      } else {
+        datetime = datetimeFromISO(string)
+      }
+
+      return datetime
+    },
     setValue (event) {
-      this.datetime = datetimeFromISO(event.target.value)
+      this.datetime = this.prepareDateString(event.target.value)
       this.emitInput()
     }
   }

--- a/src/util.js
+++ b/src/util.js
@@ -11,6 +11,12 @@ export function datetimeFromISO (string) {
   return datetime.isValid ? datetime : null
 }
 
+export function datetimeFromFormat (string, format, zone = 'utc') {
+  const datetime = DateTime.fromFormat(string, format, { zone }).toUTC()
+
+  return datetime.isValid ? datetime : null
+}
+
 export function monthDays (year, month, weekStart) {
   const monthDate = DateTime.local(year, month, 1)
   let firstDay = monthDate.weekday - weekStart

--- a/test/specs/Datetime.spec.js
+++ b/test/specs/Datetime.spec.js
@@ -331,6 +331,26 @@ describe('Datetime.vue', function () {
         done()
       })
     })
+
+    it('should pass value format to popup', function (done) {
+      const vm = createVM(this,
+        `<Datetime type="datetime" :value-format="format"></Datetime>`,
+        {
+          components: { Datetime },
+          data () {
+            return {
+              format: 'yyyy-MM-dd HH:mm:ss'
+            }
+          }
+        })
+
+      vm.$('.vdatetime-input').click()
+
+      vm.$nextTick(() => {
+        expect(vm.$findChild('.vdatetime-popup').valueFormat).to.be.equal('yyyy-MM-dd HH:mm:ss')
+        done()
+      })
+    })
   })
 
   describe('types', function () {
@@ -442,6 +462,22 @@ describe('Datetime.vue', function () {
         })
 
       expect(vm.datetime).to.be.equal('2017-12-07T16:34:54.078Z')
+    })
+
+    it('should be a formatted string when provided', function () {
+      const vm = createVM(this,
+        `<Datetime type="datetime" :value-format="format" v-model="datetime"></Datetime>`,
+        {
+          components: { Datetime },
+          data () {
+            return {
+              datetime: '2019 July 01 12:00:00',
+              format: 'yyyy LLLL dd HH:mm:ss'
+            }
+          }
+        })
+
+      expect(vm.datetime).to.be.equal('2019 July 01 12:00:00')
     })
 
     it('should be a date in the specified time zone', function () {


### PR DESCRIPTION
Added new props `value-format` to change output string accordingly instead of default `ISO8601` string. When not provided, it fallback as normal to `ISO8601` format.

