### PR TITLE
Remove warning "Can't resolve 'weekstart'"

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -119,7 +119,7 @@ export function weekStart () {
   let weekstart
 
   try {
-    weekstart = require('weekstart')
+    weekstart = require('weekstart/package.json').version ? require('weekstart') : null
   } catch (e) {
     weekstart = window.weekstart
   }


### PR DESCRIPTION
fix weekstart not found