### PR TITLE
Add type=time to the time example

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -77,7 +77,7 @@
       </div>
     </div>
     <div class="example-code">
-      <pre><code>&#x3C;datetime v-model=&#x22;time&#x22;&#x3E;&#x3C;/datetime&#x3E;</code></pre>
+      <pre><code>&#x3C;datetime type=&#x22;time&#x22; v-model=&#x22;time&#x22;&#x3E;&#x3C;/datetime&#x3E;</code></pre>
     </div>
   </div>
 


### PR DESCRIPTION
Add `type="time"` to the `time` example. 

Prevent confusion when someone read this demo example again.