### PR TITLE
add curly brackets to export name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install --save luxon vue-datetime weekstart
 
 ```js
 import Vue from 'vue'
-import Datetime from 'vue-datetime'
+import { Datetime } from 'vue-datetime'
 // You need a specific loader for CSS files
 import 'vue-datetime/dist/vue-datetime.css'
 


### PR DESCRIPTION
Hi!

I read README.md and implemented my app along the documentation. But I found an error as follows.

![スクリーンショット 2019-10-04 15 23 13](https://user-images.githubusercontent.com/42925670/66185603-ee6df580-e6ba-11e9-96dc-aed3c9a95e04.png)

The Register section in README said as follows:

```
import Datetime from 'vue-datetime'
```

But I suppose this would be like as follows:

```
import { Datetime } from 'vue-datetime'
```