### PR TITLE
FIX: Update dependency version of the rollup-plugin-vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-postcss": "^0.4.1",
     "rollup-plugin-replace": "^1.1.0",
-    "rollup-plugin-vue": "^2.3.0",
+    "rollup-plugin-vue": "^5.1.6",
     "sinon": "2.2.0",
     "sinon-chai": "^2.10.0",
     "style-loader": "^0.17.0",


### PR DESCRIPTION
Update dependency version of the rollup-plugin-vue since the latest 2.x is not compatible with newer vue stack (see https://github.com/vuejs/rollup-plugin-vue/issues/273)