### PR TITLE
current month's notation has been changed.

### DIFF
--- a/src/DatetimeCalendar.vue
+++ b/src/DatetimeCalendar.vue
@@ -6,7 +6,7 @@
           <path fill="none" stroke="#444" stroke-width="14" stroke-miterlimit="10" d="M56.3 97.8L9.9 51.4 56.3 5"/>
         </svg>
       </div>
-      <div class="vdatetime-calendar__current--month">{{ monthName }} {{ newYear }}</div>
+      <div class="vdatetime-calendar__current--month">{{ yearMonth }}</div>
       <div class="vdatetime-calendar__navigation--next" @click="nextMonth">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 61.3 102.8">
           <path fill="none" stroke="#444" stroke-width="14" stroke-miterlimit="10" d="M56.3 97.8L9.9 51.4 56.3 5"/>
@@ -66,14 +66,14 @@ export default {
   },
 
   computed: {
+    yearMonth () {
+      return this.newDate.toLocaleString({ year: 'numeric', month: 'long' })
+    },
     newYear () {
       return this.newDate.year
     },
     newMonth () {
       return this.newDate.month
-    },
-    monthName () {
-      return this.months[this.newMonth - 1]
     },
     days () {
       return monthDays(this.newYear, this.newMonth, this.weekStart).map(day => ({

--- a/test/specs/DatetimeCalendar.spec.js
+++ b/test/specs/DatetimeCalendar.spec.js
@@ -30,7 +30,7 @@ describe('DatetimeCalendar.vue', function () {
           components: { DatetimeCalendar }
         })
 
-      expect(vm.$('.vdatetime-calendar__current--month')).to.have.text('Julio 2018')
+      expect(vm.$('.vdatetime-calendar__current--month')).to.have.text('julio de 2018')
 
       const weekdays = vm.$$('.vdatetime-calendar__month__weekday').map(el => el.textContent)
       expect(weekdays).deep.equal(['Lun.', 'Mar.', 'Mié.', 'Jue.', 'Vie.', 'Sáb.', 'Dom.'])


### PR DESCRIPTION
Since the notation for the current month is not supported outside of the US, it has been changed to support notation such as Asia. Thank you! ( See https://github.com/mariomka/vue-datetime/issues/228