### PR TITLE
Ability to open without a click event.

### DIFF
--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -209,8 +209,9 @@ export default {
       this.$emit('input', datetime ? datetime.toISO() : '')
     },
     open (event) {
-      event.target.blur()
-
+      if (event) {
+        event.target.blur()
+      }
       this.isOpen = true
     },
     close () {


### PR DESCRIPTION
Would like the ability to programmatically open the datepicker modal without a click event using something like this.$refs.mydatepicker.open().