### PR TITLE
Datetime check function prop 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ flow | `Array` | Depends of *type* | Customize steps flow, steps available: time
 title | `String` | `''` | Popup title.
 hide-backdrop | `Boolean` | `false` | Show/Hide backdrop.
 backdrop-click | `Boolean` | `true` | Enable/Disable backdrop click to cancel (outside click).
-
+datetime-disabled-checker | `Function` | `(year, month, day, hour, minute, second) => false` |  For each possible option selection the appropriate date parts are provided to allow for a custom validation function for allowed selections
 Input inherits all props not defined above but `style` and `class` will be inherited by root element. [See inheritAttrs option](https://vuejs.org/v2/api/#inheritAttrs)
 
 The component is based on [Luxon](https://github.com/moment/luxon), check out [documentation](https://moment.github.io/luxon/docs/index.html) to set [time zones](https://moment.github.io/luxon/docs/manual/zones.html) and [format](https://moment.github.io/luxon/docs/manual/formatting.html).

--- a/demo/index.html
+++ b/demo/index.html
@@ -140,6 +140,7 @@
   :minute-step=&#x22;15&#x22;
   :min-datetime=&#x22;minDatetime&#x22;
   :max-datetime=&#x22;maxDatetime&#x22;
+  :datetime-disabled-checker=&#x22;datetimeDisabledChecker&#x22;
   :week-start=&#x22;7&#x22;
   use12-hour
   auto

--- a/demo/index.html
+++ b/demo/index.html
@@ -115,6 +115,7 @@
           :minute-step="15"
           :min-datetime="minDatetime"
           :max-datetime="maxDatetime"
+          :datetime-disabled-checker="datetimeDisabledChecker"
           :week-start="7"
           use12-hour
           auto

--- a/demo/src/app.js
+++ b/demo/src/app.js
@@ -17,10 +17,76 @@ new Vue({
       datetime12: '2018-05-12T17:19:06.151Z',
       datetime13: '2018-05-12T17:19:06.151Z',
       datetimeEmpty: '',
-      minDatetime: LuxonDateTime.local().minus({ month: 1, days: 3 }).toISO(),
-      maxDatetime: LuxonDateTime.local().plus({ days: 3 }).toISO(),
+      minDatetime: LuxonDateTime.local().minus({
+        month: 1,
+        days: 3
+      }).toISO(),
+      maxDatetime: LuxonDateTime.local().plus({
+        days: 3
+      }).toISO(),
+      datetimeDisabledChecker: (year, month, day, hour, minute, second) => {
+        const invalidDatetimes = [
+          [LuxonDateTime.local().minus({
+            days: 8
+          }), LuxonDateTime.local().minus({
+            days: 6
+          })],
+          [LuxonDateTime.local().minus({
+            days: 3
+          }), LuxonDateTime.local().minus({
+            days: 2,
+            hours: 12
+          })]
+        ]
+        const dateToCheck = LuxonDateTime.fromObject({
+          year,
+          month,
+          day,
+          hour,
+          minute,
+          second,
+          zone: 'UTC'
+        })
+
+        const res = invalidDatetimes.reduce((acc, val) => {
+          // if still false check otherwise its already invalid
+          if (!acc) {
+            const startDateObject = {
+              zone: 'UTC'
+            }
+            const endDateObject = {
+              zone: 'UTC'
+            }
+            let startDate = val[0]
+            let endDate = val[1]
+
+            const dateOptions = ['year', 'month']
+            if (day != null) {
+              dateOptions.push('day')
+            }
+            if (minute != null) {
+              dateOptions.push('minute')
+            }
+            if (hour != null) {
+              dateOptions.push('hour')
+            }
+
+            dateOptions.map(option => {
+              startDateObject[option] = startDate.c[option]
+            })
+            dateOptions.map(option => {
+              endDateObject[option] = endDate.c[option]
+            })
+            startDate = LuxonDateTime.fromObject(startDateObject)
+            endDate = LuxonDateTime.fromObject(endDateObject)
+
+            acc = (dateToCheck > startDate) && (dateToCheck < endDate)
+          }
+          return acc
+        }, false)
+        return res
+      },
       datetimeTheming: LuxonDateTime.local().toISO()
     }
   }
 })
-

--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -122,7 +122,7 @@ export default {
     },
     datetimeDisabledChecker: {
       type: Function,
-      default: (year, month, day, hour, minute, second) => true
+      default: (year, month, day, hour, minute, second) => false
     },
     auto: {
       type: Boolean,

--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -23,6 +23,7 @@
           :phrases="phrases"
           :use12-hour="use12Hour"
           :hour-step="hourStep"
+          :datetime-disabled-checker="datetimeDisabledChecker"
           :minute-step="minuteStep"
           :min-datetime="popupMinDatetime"
           :max-datetime="popupMaxDatetime"
@@ -118,6 +119,10 @@ export default {
     maxDatetime: {
       type: String,
       default: null
+    },
+    datetimeDisabledChecker: {
+      type: Function,
+      default: (year, month, day, hour, minute, second) => true
     },
     auto: {
       type: Boolean,

--- a/src/DatetimeCalendar.vue
+++ b/src/DatetimeCalendar.vue
@@ -45,7 +45,7 @@ export default {
     },
     datetimeDisabledChecker: {
       type: Function,
-      default: (year, month, day, hour, minute, second) => true
+      default: (year, month, day, hour, minute, second) => false
     },
     minDate: {
       type: DateTime,

--- a/src/DatetimeCalendar.vue
+++ b/src/DatetimeCalendar.vue
@@ -43,6 +43,10 @@ export default {
     disabled: {
       type: Array
     },
+    datetimeDisabledChecker: {
+      type: Function,
+      default: (year, month, day, hour, minute, second) => true
+    },
     minDate: {
       type: DateTime,
       default: null
@@ -79,7 +83,7 @@ export default {
       return monthDays(this.newYear, this.newMonth, this.weekStart).map(day => ({
         number: day,
         selected: day && this.year === this.newYear && this.month === this.newMonth && this.day === day,
-        disabled: !day || monthDayIsDisabled(this.minDate, this.maxDate, this.newYear, this.newMonth, day)
+        disabled: !day || monthDayIsDisabled(this.minDate, this.maxDate, this.newYear, this.newMonth, day) || this.datetimeDisabledChecker(this.newYear, this.newMonth, day)
       }))
     }
   },

--- a/src/DatetimeMonthPicker.vue
+++ b/src/DatetimeMonthPicker.vue
@@ -31,7 +31,7 @@ export default {
     },
     datetimeDisabledChecker: {
       type: Function,
-      default: (year, month, day, hour, minute, second) => true
+      default: (year, month, day, hour, minute, second) => false
     }
   },
 

--- a/src/DatetimeMonthPicker.vue
+++ b/src/DatetimeMonthPicker.vue
@@ -28,6 +28,10 @@ export default {
     maxDate: {
       type: DateTime,
       default: null
+    },
+    datetimeDisabledChecker: {
+      type: Function,
+      default: (year, month, day, hour, minute, second) => true
     }
   },
 
@@ -37,7 +41,7 @@ export default {
         number: ++index,
         label: month,
         selected: index === this.month,
-        disabled: !index || monthIsDisabled(this.minDate, this.maxDate, this.year, index)
+        disabled: !index || monthIsDisabled(this.minDate, this.maxDate, this.year, index) || this.datetimeDisabledChecker(this.year, month)
       }))
     }
   },

--- a/src/DatetimeMonthPicker.vue
+++ b/src/DatetimeMonthPicker.vue
@@ -41,7 +41,7 @@ export default {
         number: ++index,
         label: month,
         selected: index === this.month,
-        disabled: !index || monthIsDisabled(this.minDate, this.maxDate, this.year, index) || this.datetimeDisabledChecker(this.year, month)
+        disabled: !index || monthIsDisabled(this.minDate, this.maxDate, this.year, index) || this.datetimeDisabledChecker(this.year, index)
       }))
     }
   },

--- a/src/DatetimePopup.vue
+++ b/src/DatetimePopup.vue
@@ -40,6 +40,7 @@
           :use12-hour="use12Hour"
           :hour-step="hourStep"
           :minute-step="minuteStep"
+          :current-date-time="newDatetime"
           :datetime-disabled-checker="datetimeDisabledChecker"
           :min-time="minTime"
           :max-time="maxTime"></datetime-time-picker>
@@ -91,7 +92,7 @@ export default {
     },
     datetimeDisabledChecker: {
       type: Function,
-      default: (year, month, day, hour, minute, second) => true
+      default: (year, month, day, hour, minute, second) => false
     },
     type: {
       type: String,

--- a/src/DatetimePopup.vue
+++ b/src/DatetimePopup.vue
@@ -11,12 +11,14 @@
           @change="onChangeYear"
           :min-date="minDatetime"
           :max-date="maxDatetime"
+          :datetime-disabled-checker="datetimeDisabledChecker"
           :year="year"></datetime-year-picker>
       <datetime-month-picker
           v-if="step === 'month'"
           @change="onChangeMonth"
           :min-date="minDatetime"
           :max-date="maxDatetime"
+          :datetime-disabled-checker="datetimeDisabledChecker"
           :year="year"
           :month="month"></datetime-month-picker>
       <datetime-calendar
@@ -27,6 +29,7 @@
           :day="day"
           :min-date="minDatetime"
           :max-date="maxDatetime"
+          :datetime-disabled-checker="datetimeDisabledChecker"
           :week-start="weekStart"
       ></datetime-calendar>
       <datetime-time-picker
@@ -37,6 +40,7 @@
           :use12-hour="use12Hour"
           :hour-step="hourStep"
           :minute-step="minuteStep"
+          :datetime-disabled-checker="datetimeDisabledChecker"
           :min-time="minTime"
           :max-time="maxTime"></datetime-time-picker>
     </div>
@@ -84,6 +88,10 @@ export default {
           ok: 'Ok'
         }
       }
+    },
+    datetimeDisabledChecker: {
+      type: Function,
+      default: (year, month, day, hour, minute, second) => true
     },
     type: {
       type: String,

--- a/src/DatetimeTimePicker.vue
+++ b/src/DatetimeTimePicker.vue
@@ -6,15 +6,24 @@
     <div class="vdatetime-time-picker__list vdatetime-time-picker__list--minutes" ref="minuteList">
       <div class="vdatetime-time-picker__item" v-for="minute in minutes" @click="selectMinute(minute)" :class="{'vdatetime-time-picker__item--selected': minute.selected, 'vdatetime-time-picker__item--disabled': minute.disabled}">{{ minute.number }}</div>
     </div>
-    <div class="vdatetime-time-picker__list vdatetime-time-picker__list--suffix" ref="suffixList" v-if="use12Hour">
-      <div class="vdatetime-time-picker__item" @click="selectSuffix('am')" :class="{'vdatetime-time-picker__item--selected': hour < 12}">am</div>
-      <div class="vdatetime-time-picker__item" @click="selectSuffix('pm')" :class="{'vdatetime-time-picker__item--selected': hour >= 12}">pm</div>
+    <div
+      class="vdatetime-time-picker__list vdatetime-time-picker__list--suffix"
+      ref="suffixList"
+      v-if="use12Hour"
+    >
+      <div
+        class="vdatetime-time-picker__item"
+        v-for="timeSelection in timeSelections"
+        :key="`selection-${timeSelection}`"
+        @click="selectSuffix(timeSelection)"
+        :class="{'vdatetime-time-picker__item--selected': timeSelection.comparison(hour) , 'vdatetime-time-picker__item--disabled': timeSelection.disabled }"
+      >{{ timeSelection.id }}</div>
     </div>
   </div>
 </template>
 
 <script>
-import { hours, minutes, pad, timeComponentIsDisabled } from './util'
+import { hours, minutes, pad, timeComponentIsDisabled, selectionIsDisabled } from './util'
 import { DateTime } from 'luxon'
 
 export default {
@@ -58,6 +67,22 @@ export default {
   },
 
   computed: {
+    timeSelections () {
+      return this.use12Hour
+        ? [
+          {
+            id: 'am',
+            comparison: (hour) => hour < 12,
+            disabled: selectionIsDisabled(this.hours, this.use12Hour, 'am')
+          },
+          {
+            id: 'pm',
+            comparison: (hour) => hour >= 12,
+            disabled: selectionIsDisabled(this.hours, this.use12Hour, 'pm')
+          }
+        ]
+        : []
+    },
     hours () {
       const year = this.currentDateTime.c.year
       const month = this.currentDateTime.c.month

--- a/src/DatetimeTimePicker.vue
+++ b/src/DatetimeTimePicker.vue
@@ -15,6 +15,7 @@
 
 <script>
 import { hours, minutes, pad, timeComponentIsDisabled } from './util'
+import { DateTime } from 'luxon'
 
 export default {
   props: {
@@ -34,6 +35,14 @@ export default {
       type: Number,
       default: 1
     },
+    datetimeDisabledChecker: {
+      type: Function,
+      default: (year, month, day, hour, minute, second) => true
+    },
+    currentDateTime: {
+      type: DateTime,
+      default: () => DateTime.utc()
+    },
     minuteStep: {
       type: Number,
       default: 1
@@ -50,6 +59,9 @@ export default {
 
   computed: {
     hours () {
+      const year = this.currentDateTime.c.year
+      const month = this.currentDateTime.c.month
+      const day = this.currentDateTime.c.day
       return hours(this.hourStep).filter(hour => {
         if (!this.use12Hour) {
           return true
@@ -63,14 +75,17 @@ export default {
       }).map(hour => ({
         number: pad(hour),
         selected: hour === this.hour,
-        disabled: timeComponentIsDisabled(this.minHour, this.maxHour, hour)
+        disabled: timeComponentIsDisabled(this.minHour, this.maxHour, hour) || this.datetimeDisabledChecker(year, month, day, hour)
       }))
     },
     minutes () {
+      const year = this.currentDateTime.c.year
+      const month = this.currentDateTime.c.month
+      const day = this.currentDateTime.c.day
       return minutes(this.minuteStep).map(minute => ({
         number: pad(minute),
         selected: minute === this.minute,
-        disabled: timeComponentIsDisabled(this.minMinute, this.maxMinute, minute)
+        disabled: timeComponentIsDisabled(this.minMinute, this.maxMinute, minute) || this.datetimeDisabledChecker(year, month, day, this.hour, minute)
       }))
     },
     minHour () {

--- a/src/DatetimeTimePicker.vue
+++ b/src/DatetimeTimePicker.vue
@@ -37,7 +37,7 @@ export default {
     },
     datetimeDisabledChecker: {
       type: Function,
-      default: (year, month, day, hour, minute, second) => true
+      default: (year, month, day, hour, minute, second) => false
     },
     currentDateTime: {
       type: DateTime,

--- a/src/DatetimeYearPicker.vue
+++ b/src/DatetimeYearPicker.vue
@@ -27,7 +27,7 @@ export default {
     },
     datetimeDisabledChecker: {
       type: Function,
-      default: (year, month, day, hour, minute, second) => true
+      default: (year, month, day, hour, minute, second) => false
     }
   },
 

--- a/src/DatetimeYearPicker.vue
+++ b/src/DatetimeYearPicker.vue
@@ -24,6 +24,10 @@ export default {
     maxDate: {
       type: DateTime,
       default: null
+    },
+    datetimeDisabledChecker: {
+      type: Function,
+      default: (year, month, day, hour, minute, second) => true
     }
   },
 
@@ -32,7 +36,7 @@ export default {
       return years(this.year).map(year => ({
         number: year,
         selected: year === this.year,
-        disabled: !year || yearIsDisabled(this.minDate, this.maxDate, year)
+        disabled: !year || yearIsDisabled(this.minDate, this.maxDate, year) || this.datetimeDisabledChecker(year)
       }))
     }
   },

--- a/src/util.js
+++ b/src/util.js
@@ -52,6 +52,18 @@ export function yearIsDisabled (minDate, maxDate, year) {
          (maxYear && year > maxYear)
 }
 
+export function selectionIsDisabled (hours, use12Hour, selection) {
+  // if not use12hours
+  const enabledHours = hours.filter(hour => !hour.disabled)
+  let hasSelection = enabledHours.length > 0
+  if (use12Hour) {
+    hasSelection = !!enabledHours.find(hour =>
+      selection === 'am' ? hour.number < 12 : hour.number >= 12
+    )
+  }
+  return !hasSelection
+}
+
 export function timeComponentIsDisabled (min, max, component) {
   return (min !== null && component < min) ||
          (max !== null && component > max)

--- a/test/specs/Datetime.spec.js
+++ b/test/specs/Datetime.spec.js
@@ -262,6 +262,26 @@ describe('Datetime.vue', function () {
       })
     })
 
+    it('should pass datetime disabled checker function to popup', function (done) {
+      const vm = createVM(this,
+        `<Datetime type="datetime" :datetime-disabled-checker="datetimeDisabledChecker"></Datetime>`,
+        {
+          components: { Datetime },
+          data () {
+            return {
+              datetimeDisabledChecker: (year) => year === 2000
+            }
+          }
+        })
+
+      vm.$('.vdatetime-input').click()
+
+      vm.$nextTick(() => {
+        expect(vm.$findChild('.vdatetime-popup').datetimeDisabledChecker(2000)).to.be.equal(true)
+        done()
+      })
+    })
+
     it('should pass auto to popup', function (done) {
       const vm = createVM(this,
         `<Datetime auto></Datetime>`,

--- a/test/specs/DatetimeCalendar.spec.js
+++ b/test/specs/DatetimeCalendar.spec.js
@@ -63,6 +63,32 @@ describe('DatetimeCalendar.vue', function () {
       expect(vm.$('.vdatetime-calendar__month__day--selected')).to.have.text('10')
     })
 
+    it('should disable days considered invalid by datetime checker', function () {
+      const vm = createVM(this,
+        `<DatetimeCalendar :year="2018" :month="7" :day="10" :datetime-disabled-checker="datetimeDisabledChecker"></DatetimeCalendar>`,
+        {
+          components: { DatetimeCalendar },
+          data () {
+            return {
+              datetimeDisabledChecker: (year, month, day) => {
+                return LuxonDatetime.fromObject({ year, month, day, timezone: 'UTC' }) < LuxonDatetime.fromISO('2018-07-06T00:00:00.000Z').toUTC()
+              }
+            }
+          }
+        })
+
+      const monthDays = vm.$$('.vdatetime-calendar__month__day')
+
+      monthDays.forEach(monthDay => {
+        const dayNumber = parseInt(monthDay.textContent)
+        if (isNaN(dayNumber) || dayNumber < 7) {
+          expect(monthDay).to.have.class('vdatetime-calendar__month__day--disabled')
+        } else {
+          expect(monthDay).to.have.not.class('vdatetime-calendar__month__day--disabled')
+        }
+      })
+    })
+
     it('should disable days before min date', function () {
       const vm = createVM(this,
         `<DatetimeCalendar :year="2018" :month="7" :day="10" :min-date="minDate"></DatetimeCalendar>`,

--- a/test/specs/DatetimeMonthsPicker.spec.js
+++ b/test/specs/DatetimeMonthsPicker.spec.js
@@ -45,6 +45,33 @@ describe('DatetimeMonthPicker.vue', function () {
         }
       })
     })
+
+    it('should disable months given disabled datetime checker', function () {
+      const vm = createVM(this,
+        `<DatetimeMonthPicker :datetime-disabled-checker="datetimeDisabledChecker" :year="2018" :month="10"></DatetimeMonthPicker>`,
+        {
+          components: { DatetimeMonthPicker },
+          data () {
+            return {
+              datetimeDisabledChecker: (_year, month) => {
+                return month < 7
+              }
+            }
+          }
+        })
+
+      const months = vm.$$('.vdatetime-month-picker__list .vdatetime-month-picker__item')
+
+      months.forEach(month => {
+        const monthName = month.textContent.trim()
+
+        if (!(['July', 'August', 'September', 'October', 'November', 'December'].indexOf(monthName) === -1)) {
+          expect(month).to.have.not.class('vdatetime-month-picker__item--disabled')
+        } else {
+          expect(month).to.have.class('vdatetime-month-picker__item--disabled')
+        }
+      })
+    })
   })
 
   describe('events', function () {

--- a/test/specs/DatetimePopup.spec.js
+++ b/test/specs/DatetimePopup.spec.js
@@ -305,6 +305,21 @@ describe('DatetimePopup.vue', function () {
       })
     })
 
+    it('should pass datetime disabled checker function to popup', function () {
+      const vm = createVM(this,
+        `<DatetimePopup :datetime="datetime" type="datetime" :datetime-disabled-checker="datetimeDisabledChecker"></DatetimePopup>`,
+        {
+          components: { DatetimePopup },
+          data () {
+            return {
+              datetime: LuxonDatetime.local(),
+              datetimeDisabledChecker: (year) => year === 2000
+            }
+          }
+        })
+      expect(vm.$findChild('.vdatetime-calendar').datetimeDisabledChecker(2000)).to.be.equal(true)
+    })
+
     it('should pass min and max date to calendar', function () {
       const vm = createVM(this,
         `<DatetimePopup :datetime="datetime" type="datetime" :min-datetime="minDatetime" :max-datetime="maxDatetime"></DatetimePopup>`,
@@ -314,7 +329,7 @@ describe('DatetimePopup.vue', function () {
             return {
               datetime: LuxonDatetime.local(),
               minDatetime: LuxonDatetime.fromISO('2018-01-01T12:35:22.000Z'),
-              maxDatetime: LuxonDatetime.fromISO('2018-01-03T20:43:13.000Z')
+              maxDatetime: LuxonDatetime.fromISO('2018-01-03T12:43:13.000Z')
             }
           }
         })
@@ -324,8 +339,8 @@ describe('DatetimePopup.vue', function () {
     })
 
     it('should pass min and max time to time picker when date are equals', function (done) {
-      const minDatetime = LuxonDatetime.fromISO('2018-01-01T12:35:22.000Z')
-      const maxDatetime = LuxonDatetime.fromISO('2018-01-01T20:43:13.000Z')
+      const minDatetime = LuxonDatetime.fromISO('2018-01-01T08:35:22.000Z')
+      const maxDatetime = LuxonDatetime.fromISO('2018-01-01T12:43:13.000Z')
 
       const vm = createVM(this,
         `<DatetimePopup :datetime="datetime" type="datetime" :min-datetime="minDatetime" :max-datetime="maxDatetime"></DatetimePopup>`,
@@ -333,7 +348,7 @@ describe('DatetimePopup.vue', function () {
           components: { DatetimePopup },
           data () {
             return {
-              datetime: LuxonDatetime.fromISO('2018-01-01T17:42:11.000Z'),
+              datetime: LuxonDatetime.fromISO('2018-01-01T09:42:11.000Z'),
               minDatetime: minDatetime,
               maxDatetime: maxDatetime
             }

--- a/test/specs/DatetimePopup.spec.js
+++ b/test/specs/DatetimePopup.spec.js
@@ -329,7 +329,7 @@ describe('DatetimePopup.vue', function () {
             return {
               datetime: LuxonDatetime.local(),
               minDatetime: LuxonDatetime.fromISO('2018-01-01T12:35:22.000Z'),
-              maxDatetime: LuxonDatetime.fromISO('2018-01-03T12:43:13.000Z')
+              maxDatetime: LuxonDatetime.fromISO('2018-01-03T20:43:13.000Z')
             }
           }
         })
@@ -339,8 +339,8 @@ describe('DatetimePopup.vue', function () {
     })
 
     it('should pass min and max time to time picker when date are equals', function (done) {
-      const minDatetime = LuxonDatetime.fromISO('2018-01-01T08:35:22.000Z')
-      const maxDatetime = LuxonDatetime.fromISO('2018-01-01T12:43:13.000Z')
+      const minDatetime = LuxonDatetime.fromISO('2018-01-01T12:35:22.000Z')
+      const maxDatetime = LuxonDatetime.fromISO('2018-01-01T20:43:13.000Z')
 
       const vm = createVM(this,
         `<DatetimePopup :datetime="datetime" type="datetime" :min-datetime="minDatetime" :max-datetime="maxDatetime"></DatetimePopup>`,
@@ -348,7 +348,7 @@ describe('DatetimePopup.vue', function () {
           components: { DatetimePopup },
           data () {
             return {
-              datetime: LuxonDatetime.fromISO('2018-01-01T09:42:11.000Z'),
+              datetime: LuxonDatetime.fromISO('2018-01-01T17:42:11.000Z'),
               minDatetime: minDatetime,
               maxDatetime: maxDatetime
             }

--- a/test/specs/DatetimeYearPicker.spec.js
+++ b/test/specs/DatetimeYearPicker.spec.js
@@ -23,7 +23,7 @@ describe('DatetimeYearPicker.vue', function () {
       expect(selected).eql(2020)
     })
 
-    it('should disable years', function () {
+    it('should disable years given min max', function () {
       const vm = createVM(this,
         `<DatetimeYearPicker :min-date="minDate" :max-date="maxDate" :year="2018"></DatetimeYearPicker>`,
         {
@@ -32,6 +32,33 @@ describe('DatetimeYearPicker.vue', function () {
             return {
               minDate: DateTime.fromISO('2018-01-01T00:00:00.000Z').toUTC(),
               maxDate: DateTime.fromISO('2018-12-01T00:00:00.000Z').toUTC()
+            }
+          }
+        })
+
+      const years = vm.$$('.vdatetime-year-picker__list .vdatetime-year-picker__item')
+
+      years.forEach(year => {
+        const yearNumber = parseInt(year.textContent)
+
+        if (yearNumber === 2018) {
+          expect(year).to.have.not.class('vdatetime-year-picker__item--disabled')
+        } else {
+          expect(year).to.have.class('vdatetime-year-picker__item--disabled')
+        }
+      })
+    })
+
+    it('should disable years given datetime disabled checker', function () {
+      const vm = createVM(this,
+        `<DatetimeYearPicker :datetime-disabled-checker="datetimeDisabledChecker" :year="2018"></DatetimeYearPicker>`,
+        {
+          components: { DatetimeYearPicker },
+          data () {
+            return {
+              datetimeDisabledChecker: (year) => {
+                return year !== 2018
+              }
             }
           }
         })


### PR DESCRIPTION
Hey @mariomka 

Sorry for the wait had been busy.
Update from previous pr https://github.com/mariomka/vue-datetime/pull/226

* added new prop datetime-disabled-checker, this provides (year,month,day,hour,minute,second) as params to the provided function
* there is an example of how ranges could be implemented in the demo changes
* added functionality to disable am/pm when no selections available
* added tests