### PR TITLE
Emit an 'open' event when the popup is opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Settings.defaultLocale = 'es'
 
 Component emits the `input` event to work with `v-model`. [More info](https://vuejs.org/v2/guide/components.html#Form-Input-Components-using-Custom-Events).
 
+`open` event is emitted when the popup opens.
+
 `close` event is emitted when the popup closes.
 
 Also, input text inherits all component events.

--- a/src/Datetime.vue
+++ b/src/Datetime.vue
@@ -212,6 +212,8 @@ export default {
       event.target.blur()
 
       this.isOpen = true
+
+      this.$emit('open')
     },
     close () {
       this.isOpen = false

--- a/test/specs/Datetime.spec.js
+++ b/test/specs/Datetime.spec.js
@@ -998,6 +998,27 @@ describe('Datetime.vue', function () {
       })
     })
 
+    it('should emit open when popup opens', function (done) {
+      const vm = createVM(this,
+        `<Datetime @open="spy"></Datetime>`,
+        {
+          components: { Datetime },
+          data () {
+            return {
+              spy: sinon.spy()
+            }
+          }
+        })
+
+      expect(vm.spy).to.have.not.been.called
+      vm.$('.vdatetime-input').click()
+
+      vm.$nextTick(() => {
+        expect(vm.spy).to.have.been.calledOnce
+        done()
+      })
+    })
+
     it('should emit close when popup closes', function (done) {
       const vm = createVM(this,
         `<Datetime @close="spy"></Datetime>`,

--- a/test/specs/DatetimeCalendar.spec.js
+++ b/test/specs/DatetimeCalendar.spec.js
@@ -33,7 +33,7 @@ describe('DatetimeCalendar.vue', function () {
       expect(vm.$('.vdatetime-calendar__current--month')).to.have.text('Julio 2018')
 
       const weekdays = vm.$$('.vdatetime-calendar__month__weekday').map(el => el.textContent)
-      expect(weekdays).deep.equal(['Lun.', 'Mar.', 'Mié.', 'Jue.', 'Vie.', 'Sáb.', 'Dom.'])
+      expect(weekdays).deep.equal(['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'])
     })
 
     it('should render a calendar with other week start', function () {


### PR DESCRIPTION
This solves issue #137 using the same approach as pull request #175. A README update and test is included.

To pass tests I had to update the default locale test in `DatetimeCalendar.spec.js`. The test was rendering each weekday's name without a period ex. `Lun` but it was expecting a period `Lun.`. I suspect this was due to changes outside of this project's scope. Hopefully this change isn't a problem.